### PR TITLE
feat!: refactor sign_message and update to 0.7.0 eth-ape

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -20,15 +20,15 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: python
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -9,12 +9,12 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v4
           with:
               fetch-depth: 0
 
         - name: Setup Python
-          uses: actions/setup-python@v4
+          uses: actions/setup-python@v5
           with:
               python-version: "3.10"
 

--- a/.github/workflows/prtitle.yaml
+++ b/.github/workflows/prtitle.yaml
@@ -12,10 +12,10 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v4
 
         - name: Setup Python
-          uses: actions/setup-python@v4
+          uses: actions/setup-python@v5
           with:
               python-version: "3.10"
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.10"
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,10 +14,10 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v4
 
         - name: Setup Python
-          uses: actions/setup-python@v4
+          uses: actions/setup-python@v5
           with:
               python-version: "3.10"
 
@@ -42,10 +42,10 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v4
 
         - name: Setup Python
-          uses: actions/setup-python@v4
+          uses: actions/setup-python@v5
           with:
               python-version: "3.10"
 
@@ -66,10 +66,10 @@ jobs:
                 python-version: [3.8, 3.9, "3.10", "3.11"]
 
         steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v4
 
         - name: Setup Python
-          uses: actions/setup-python@v4
+          uses: actions/setup-python@v5
           with:
               python-version: ${{ matrix.python-version }}
 
@@ -89,10 +89,10 @@ jobs:
 #            fail-fast: true
 #
 #        steps:
-#        - uses: actions/checkout@v3
+#        - uses: actions/checkout@v4
 #
 #        - name: Setup Python
-#          uses: actions/setup-python@v4
+#          uses: actions/setup-python@v5
 #          with:
 #              python-version: "3.10"
 #

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,18 +10,18 @@ repos:
       - id: isort
 
 -   repo: https://github.com/psf/black
-    rev: 23.11.0
+    rev: 24.2.0
     hooks:
       - id: black
         name: black
 
 -   repo: https://github.com/pycqa/flake8
-    rev: 6.1.0
+    rev: 7.0.0
     hooks:
     -   id: flake8
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.6.1
+    rev: v1.8.0
     hooks:
     -   id: mypy
         additional_dependencies: [types-requests, types-setuptools]

--- a/ape_frame/accounts.py
+++ b/ape_frame/accounts.py
@@ -38,7 +38,7 @@ class FrameAccount(AccountAPI):
     @property
     def web3(self) -> Web3:
         headers = {
-            "Origin": "Ape",
+            "Origin": "Ape/ape-frame/account",
             "User-Agent": "ape-frame/0.1.0",
             "Content-Type": "application/json",
         }

--- a/ape_frame/providers.py
+++ b/ape_frame/providers.py
@@ -1,8 +1,8 @@
 from typing import Any
 
 from ape.api import UpstreamProvider
-from ape_ethereum.provider import Web3Provider
 from ape.exceptions import ProviderError
+from ape_ethereum.provider import Web3Provider
 from eth_utils import to_hex
 from requests import HTTPError  # type: ignore[import]
 from web3 import HTTPProvider, Web3
@@ -28,7 +28,7 @@ class FrameProvider(Web3Provider, UpstreamProvider):
         headers = {
             "Origin": "Ape",
             "User-Agent": "ape-frame/0.1.0",
-            "Content-Type": "application/json"
+            "Content-Type": "application/json",
         }
         self._web3 = Web3(HTTPProvider(self.uri, request_kwargs={"headers": headers}))
 

--- a/ape_frame/providers.py
+++ b/ape_frame/providers.py
@@ -4,12 +4,12 @@ from ape.api import UpstreamProvider
 from ape.exceptions import ProviderError
 from ape_ethereum.provider import Web3Provider
 from eth_utils import to_hex
-from requests import HTTPError  # type: ignore[import]
+from requests import HTTPError
 from web3 import HTTPProvider, Web3
 from web3.gas_strategies.rpc import rpc_gas_price_strategy
 from web3.middleware import geth_poa_middleware
 
-from .exceptions import FrameNotConnectedError, FrameProviderError
+from ape_frame.exceptions import FrameNotConnectedError, FrameProviderError
 
 
 class FrameProvider(Web3Provider, UpstreamProvider):

--- a/ape_frame/providers.py
+++ b/ape_frame/providers.py
@@ -1,6 +1,7 @@
 from typing import Any
 
-from ape.api import UpstreamProvider, Web3Provider
+from ape.api import UpstreamProvider
+from ape_ethereum.provider import Web3Provider
 from ape.exceptions import ProviderError
 from eth_utils import to_hex
 from requests import HTTPError  # type: ignore[import]
@@ -24,7 +25,12 @@ class FrameProvider(Web3Provider, UpstreamProvider):
         return self.uri
 
     def connect(self):
-        self._web3 = Web3(HTTPProvider(self.uri))
+        headers = {
+            "Origin": "Ape",
+            "User-Agent": "ape-frame/0.1.0",
+            "Content-Type": "application/json"
+        }
+        self._web3 = Web3(HTTPProvider(self.uri, request_kwargs={"headers": headers}))
 
         if "Frame" not in self._web3.client_version:
             raise FrameNotConnectedError()

--- a/ape_frame/providers.py
+++ b/ape_frame/providers.py
@@ -26,7 +26,7 @@ class FrameProvider(Web3Provider, UpstreamProvider):
 
     def connect(self):
         headers = {
-            "Origin": "Ape",
+            "Origin": "Ape/ape-frame/provider",
             "User-Agent": "ape-frame/0.1.0",
             "Content-Type": "application/json",
         }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ write_to = "ape_frame/version.py"
 
 [tool.black]
 line-length = 100
-target-version = ['py38', 'py39', 'py310']
+target-version = ['py38', 'py39', 'py310', 'py311']
 include = '\.pyi?$'
 
 [tool.pytest.ini_options]

--- a/setup.py
+++ b/setup.py
@@ -10,16 +10,17 @@ extras_require = {
         "hypothesis>=6.2.0,<7.0",  # Strategy-based fuzzer
     ],
     "lint": [
-        "black>=23.11.0,<24",  # Auto-formatter and linter
-        "mypy>=1.6.1,<2",  # Static type analyzer
+        "black>=24.2.0,<25",  # Auto-formatter and linter
+        "mypy>=1.8.0,<2",  # Static type analyzer
         "types-requests",  # Needed due to mypy typeshed
         "types-setuptools",  # Needed due to mypy typeshed
         "types-PyYAML",  # Needed due to mypy typeshed
-        "flake8>=6.1.0,<7",  # Style linter
+        "flake8>=7.0.0,<8",  # Style linter
         "isort>=5.10.1,<6",  # Import sorting linter
         "mdformat>=0.7.17",  # Auto-formatter for markdown
         "mdformat-gfm>=0.3.5",  # Needed for formatting GitHub-flavored markdown
         "mdformat-frontmatter>=0.4.1",  # Needed for frontmatters-style headers in issue templates
+        "mdformat-pyproject>=0.0.1",  # Allows configuring in pyproject.toml
     ],
     "release": [  # `release` GitHub Action job uses this
         "setuptools",  # Installation tool
@@ -59,7 +60,7 @@ setup(
     url="https://github.com/ApeWorX/ape-frame",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.6.0,<0.7.0",
+        "eth-ape>=0.7.10,<0.8",
     ],
     python_requires=">=3.8,<4",
     extras_require=extras_require,


### PR DESCRIPTION
*note*: this will fail type checking until we release the changes in https://github.com/ApeWorX/ape/pull/1614#pullrequestreview-1591921090

now supports strings, SignableMessage, and EIP712Message

### What I did

Updated sign_message and check_message to support the types they can handle

Fixes: APE-1351
### How I did it

some type checking and lots of experimenting

### How to verify it

I used this script

```python
from eip712 import EIP712Message
from ape import accounts
from eth_account.messages import encode_defunct


class CustomMessage(EIP712Message):
    _name_ = "CustomMessage"
    _version_ = "1"
    _chainId_ = 1
    amount: "uint256"  # type: ignore
    recipient: "address"  # type: ignore


acc = accounts.load("frame")

c = CustomMessage(amount=1, recipient=acc.address)

sig = acc.sign_message("Hello World")
assert acc.check_signature("Hello World", sig)

strmsg = encode_defunct(text="Hello World")
sig = acc.sign_message(strmsg)
assert acc.check_signature(strmsg, sig)

sig = acc.sign_message(c)
assert acc.check_signature(c, sig)
```

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
