### PR TITLE
refactor: remove goerli

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,4 +33,4 @@ repos:
         additional_dependencies: [mdformat-gfm, mdformat-frontmatter, mdformat-pyproject]
 
 default_language_version:
-    python: python3.8
+    python: python3

--- a/ape_frame/__init__.py
+++ b/ape_frame/__init__.py
@@ -10,12 +10,15 @@ NETWORKS = {
     ],
     "arbitrum": [
         "mainnet",
+        "sepolia",
     ],
     "optimism": [
         "mainnet",
+        "sepolia",
     ],
     "polygon": [
         "mainnet",
+        "amoy",
     ],
 }
 

--- a/ape_frame/__init__.py
+++ b/ape_frame/__init__.py
@@ -6,7 +6,6 @@ from .providers import FrameProvider
 NETWORKS = {
     "ethereum": [
         "mainnet",
-        "goerli",
         "sepolia",
     ],
     "arbitrum": [

--- a/ape_frame/providers.py
+++ b/ape_frame/providers.py
@@ -46,8 +46,8 @@ class FrameProvider(Web3Provider, UpstreamProvider):
 
         # Any chain that *began* as PoA needs the middleware for pre-merge blocks
         ethereum_sepolia = 11155111
-        optimism = (10, 420)
-        polygon = (137, 80001)
+        optimism = (10, 11155420)
+        polygon = (137, 80002)
         try:
             if self._web3.eth.chain_id in (ethereum_sepolia, *optimism, *polygon):
                 self._web3.middleware_onion.inject(geth_poa_middleware, layer=0)

--- a/ape_frame/providers.py
+++ b/ape_frame/providers.py
@@ -45,11 +45,11 @@ class FrameProvider(Web3Provider, UpstreamProvider):
             )
 
         # Any chain that *began* as PoA needs the middleware for pre-merge blocks
-        ethereum_goerli = 5
+        ethereum_sepolia = 11155111
         optimism = (10, 420)
         polygon = (137, 80001)
         try:
-            if self._web3.eth.chain_id in (ethereum_goerli, *optimism, *polygon):
+            if self._web3.eth.chain_id in (ethereum_sepolia, *optimism, *polygon):
                 self._web3.middleware_onion.inject(geth_poa_middleware, layer=0)
 
             self._web3.eth.set_gas_price_strategy(rpc_gas_price_strategy)


### PR DESCRIPTION
### What I did

https://blog.ethereum.org/2023/11/30/goerli-lts-update
https://www.alchemy.com/blog/goerli-faucet-deprecation

Goerli support on all networks is ending soon:
- February 16th - [Base Goerli](https://www.alchemy.com/blog/base-goerli-testnet-deprecation)
- March 7th - [Optimism Goerli](https://www.alchemy.com/blog/optimism-goerli-testnet-deprecation)
- March 18th - [Arbitrum Goerli](https://www.alchemy.com/blog/arbitrum-goerli-testnet-deprecation)
- April 1st - [Ethereum Goerli](https://www.alchemy.com/blog/ethereum-goerli-testnet-deprecation)
- April 6th - [Polygon zkEVM Goerli](https://www.alchemy.com/blog/polygon-zkevm-cardona-is-live)
- April 11th - [Starknet Goerli](https://www.alchemy.com/blog/starknet-sepolia-is-live)
- April 13th - [Polygon Mumbai](https://www.alchemy.com/blog/polygon-mumbai-testnet-deprecation)

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
